### PR TITLE
url_component query test fails when query string contains repeated keys

### DIFF
--- a/lib/Test2/Tools/URL.pm
+++ b/lib/Test2/Tools/URL.pm
@@ -129,6 +129,7 @@ package Test2::Tools::URL::Check;
 
 use overload ();
 use URI 1.61;
+use URI::QueryParam;
 use Scalar::Util qw( blessed );
 use base qw( Test2::Compare::Base );
 
@@ -206,15 +207,13 @@ sub deltas
 
     if($method eq 'query' && !$check->isa('Test2::Compare::String'))
     {
-      my @query = $uri->query_form;
       if($check->isa('Test2::Compare::Hash'))
       {
-        my %query = @query;
-        $value = \%query;
+        $value = $uri->query_form_hash;
       }
       elsif($check->isa('Test2::Compare::Array'))
       {
-        $value = \@query;
+        $value = [ $uri->query_form ];
       }
     }
 

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -279,4 +279,23 @@ subtest 'windows absolute' => sub {
 
 };
 
+subtest 'query as hash with repeated keys' => sub {
+
+  is(
+    "http://example.com/page?foo=bar&lorem=ipsum",
+    url {
+      url_component query => { foo => "bar", lorem => "ipsum" };
+    },
+    "expected query for hashref without repeated keys"
+  );
+
+  is(
+    "http://example.com/page?foo=bar&foo=baz&lorem=ipsum",
+    url {
+      url_component query => { foo => [qw( bar baz )], lorem => "ipsum" };
+    },
+    "expected query for hashref with repeated keys"
+  );
+};
+
 done_testing


### PR DESCRIPTION
Discovered a problem when providing a hashref as the expected value for a url_component query test with a query string that includes a repeated value. Rather than expecting a hash with an arrayref for the value, the test was only seeing the last key value from the query.

Switching to using [URI::QueryParam's](https://metacpan.org/pod/URI::QueryParam) query_form_hash method allows this to work as expected.

I also added a test to make sure this works as expected.