### PR TITLE
add url_scheme and url_host checks

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for {{$dist->name}}
 
 {{$NEXT}}
   - Added: url_scheme, url_host, url_secure and url_insecure, url_mail_to checks (gh#6)
+  - Added: user and password components for FTP URLs (gh#6)
   - Move to new github org
 
 0.05      2019-07-15 13:03:09 -0400

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
-  - Add url_scheme and url_host checks (gh#6)
+  - Added: url_scheme, url_host, url_secure and url_insecure checks (gh#6)
   - Move to new github org
 
 0.05      2019-07-15 13:03:09 -0400

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Add url_scheme and url_host checks (gh#6)
   - Move to new github org
 
 0.05      2019-07-15 13:03:09 -0400

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
-  - Added: url_scheme, url_host, url_secure and url_insecure checks (gh#6)
+  - Added: url_scheme, url_host, url_secure and url_insecure, url_mail_to checks (gh#6)
   - Move to new github org
 
 0.05      2019-07-15 13:03:09 -0400

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ url {
 
 Check that the given URL is using an insecure protocol like `http` or `ftp`.
 
+## url\_mail\_to
+
+```
+url {
+  url_mail_to $check;
+}
+```
+
+Checks that the email address in the given `mailto` URL matches the check.
+For non-`mailto` URLs this check will fail.
+
 # SEE ALSO
 
 [Test2::Suite](https://metacpan.org/pod/Test2::Suite)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ Check that the given URL component matches.
     May be either a string, list or array!
 
 - fragment
+- user
+
+    Note: for `ftp` URLs only.
+
+- password
+
+    Note: for `ftp` URLs only.
 
 ## url\_scheme
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ use Test2::Tools::URL;
 is(
   "http://example.com/path1/path2?query=1#fragment",
   url {
-    url_component scheme   => 'http';
-    url_component host     => 'example.com';
+    url_scheme             => 'http';
+    url_host               => 'example.com';
     url_component path     => '/path1/path2';
     url_component query    => { query => 1 };
     url_component fragment => 'fragment';
@@ -65,10 +65,16 @@ url {
 Check that the given URL component matches.
 
 - scheme
+
+    Note: scheme _is_ normalized to lower case for this test.
+
 - authority
 - userinfo
 - hostport
 - host
+
+    Note: hostname _is not_ normalized to lower case for this test.  To test the normalized hostname use `url_host` below.
+
 - port
 - path
 - query
@@ -76,6 +82,28 @@ Check that the given URL component matches.
     May be either a string, list or array!
 
 - fragment
+
+## url\_scheme
+
+```
+url {
+  url_scheme $check;
+}
+```
+
+Check that the given URL scheme matches `$check`.  Note that the scheme _is_ normalized
+to lower case for this test, so it is identical to using `url_component 'scheme', $check`.
+
+## url\_host
+
+```
+url {
+  url_host $check;
+}
+```
+
+Check that the given URL host matches `$check`.  Note that the host _is_ normalized to
+lower case for this test, unlike the `url_component 'host', $check` test described above.
 
 # SEE ALSO
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,31 @@ Check that the given URL component matches.
 - fragment
 - user
 
+    \[version 0.06\]
+
     Note: for `ftp` URLs only.
 
 - password
 
+    \[version 0.06\]
+
     Note: for `ftp` URLs only.
 
+- media\_type
+
+    \[version 0.06\]
+
+    Note: for `data` URLs only.
+
+- data
+
+    \[version 0.06\]
+
+    Note: for `data` URLs only.
+
 ## url\_scheme
+
+\[version 0.06\]
 
 ```
 url {
@@ -103,6 +121,8 @@ to lower case for this test, so it is identical to using `url_component 'scheme'
 
 ## url\_host
 
+\[version 0.06\]
+
 ```
 url {
   url_host $check;
@@ -114,6 +134,8 @@ lower case for this test, unlike the `url_component 'host', $check` test describ
 
 ## url\_secure
 
+\[version 0.06\]
+
 ```
 url {
   url_secure();
@@ -124,6 +146,8 @@ Check that the given URL is using a secure protocol like `https` or `wss`.
 
 ## url\_insecure
 
+\[version 0.06\]
+
 ```
 url {
   url_insecure();
@@ -133,6 +157,8 @@ url {
 Check that the given URL is using an insecure protocol like `http` or `ftp`.
 
 ## url\_mail\_to
+
+\[version 0.06\]
 
 ```
 url {

--- a/README.md
+++ b/README.md
@@ -105,6 +105,26 @@ url {
 Check that the given URL host matches `$check`.  Note that the host _is_ normalized to
 lower case for this test, unlike the `url_component 'host', $check` test described above.
 
+## url\_secure
+
+```
+url {
+  url_secure();
+}
+```
+
+Check that the given URL is using a secure protocol like `https` or `wss`.
+
+## url\_insecure
+
+```
+url {
+  url_insecure();
+}
+```
+
+Check that the given URL is using an insecure protocol like `http` or `ftp`.
+
 # SEE ALSO
 
 [Test2::Suite](https://metacpan.org/pod/Test2::Suite)

--- a/lib/Test2/Tools/URL.pm
+++ b/lib/Test2/Tools/URL.pm
@@ -117,11 +117,27 @@ May be either a string, list or array!
 
 =item user
 
+[version 0.06]
+
 Note: for C<ftp> URLs only.
 
 =item password
 
+[version 0.06]
+
 Note: for C<ftp> URLs only.
+
+=item media_type
+
+[version 0.06]
+
+Note: for C<data> URLs only.
+
+=item data
+
+[version 0.06]
+
+Note: for C<data> URLs only.
 
 =back
 
@@ -135,7 +151,7 @@ sub url_component ($$)
   if($check_name)
   {
     Carp::croak("$name is not a valid URL component")
-      unless $name =~ /^(?:scheme|authority|userinfo|hostport|host|port|path|query|fragment|user|password)$/;
+      unless $name =~ /^(?:scheme|authority|userinfo|hostport|host|port|path|query|fragment|user|password|media_type|data)$/;
   }
 
   my $build = Test2::Compare::get_build()or Carp::croak("No current build!");
@@ -143,6 +159,8 @@ sub url_component ($$)
 }
 
 =head2 url_scheme
+
+[version 0.06]
 
  url {
    url_scheme $check;
@@ -161,6 +179,8 @@ sub url_scheme ($)
 
 =head2 url_host
 
+[version 0.06]
+
  url {
    url_host $check;
  }
@@ -177,6 +197,8 @@ sub url_host ($)
 }
 
 =head2 url_secure
+
+[version 0.06]
 
  url {
    url_secure();
@@ -202,6 +224,8 @@ sub url_secure ()
 
 =head2 url_insecure
 
+[version 0.06]
+
  url {
    url_insecure();
  }
@@ -225,6 +249,8 @@ sub url_insecure ()
 }
 
 =head2 url_mail_to
+
+[version 0.06]
 
  url {
    url_mail_to $check;

--- a/lib/Test2/Tools/URL.pm
+++ b/lib/Test2/Tools/URL.pm
@@ -115,6 +115,14 @@ May be either a string, list or array!
 
 =item fragment
 
+=item user
+
+Note: for C<ftp> URLs only.
+
+=item password
+
+Note: for C<ftp> URLs only.
+
 =back
 
 =cut
@@ -127,9 +135,9 @@ sub url_component ($$)
   if($check_name)
   {
     Carp::croak("$name is not a valid URL component")
-      unless $name =~ /^(?:scheme|authority|userinfo|hostport|host|port|path|query|fragment)$/;
+      unless $name =~ /^(?:scheme|authority|userinfo|hostport|host|port|path|query|fragment|user|password)$/;
   }
-  
+
   my $build = Test2::Compare::get_build()or Carp::croak("No current build!");
   $build->add_component($name, $expect, $lc);
 }
@@ -259,16 +267,16 @@ sub verify
 {
   my($self, %params) = @_;
   my($got, $exists) = @params{qw/ got exists /};
-  
+
   return 0 unless $exists;
   return 0 unless $got;
   return 0 if ref($got) && !blessed($got);
   return 0 if ref($got) && !overload::Method($got, '""');
-  
-  my $url = eval { $self->_uri($got) };  
+
+  my $url = eval { $self->_uri($got) };
   return 0 if $@;
   return 0 if ! $url->has_recognized_scheme;
-  
+
   return 1;
 }
 
@@ -296,13 +304,13 @@ sub deltas
   my($got, $convert, $seen) = @args{'got', 'convert', 'seen'};
 
   my $uri = $self->_uri($got);
-  
+
   my @deltas;
-  
+
   foreach my $comp (@{ $self->{component} })
   {
     my($name, $expect, $lc) = @$comp;
-    
+
     my $method = $name;
     $method = 'host_port' if $method eq 'hostport';
     my $value = $uri->can($method) ? $uri->$method : undef;
@@ -335,7 +343,7 @@ sub deltas
       got     => $value,
     );
   }
-  
+
   @deltas;
 }
 

--- a/lib/Test2/Tools/URL.pm
+++ b/lib/Test2/Tools/URL.pm
@@ -10,7 +10,7 @@ use Test2::Compare::String ();
 use Test2::Compare::Custom ();
 use base qw( Exporter );
 
-our @EXPORT = qw( url url_base url_component url_scheme url_host url_secure url_insecure );
+our @EXPORT = qw( url url_base url_component url_scheme url_host url_secure url_insecure url_mail_to );
 
 # ABSTRACT: Compare a URL in your Test2 test
 # VERSION
@@ -216,6 +216,23 @@ sub url_insecure ()
   goto &url_component;
 }
 
+=head2 url_mail_to
+
+ url {
+   url_mail_to $check;
+ }
+
+Checks that the email address in the given C<mailto> URL matches the check.
+For non-C<mailto> URLs this check will fail.
+
+=cut
+
+sub url_mail_to ($)
+{
+  @_ = ('to', $_[0], undef, 0);
+  goto &url_component;
+}
+
 package Test2::Tools::URL::Check;
 
 use overload ();
@@ -288,8 +305,8 @@ sub deltas
     
     my $method = $name;
     $method = 'host_port' if $method eq 'hostport';
-    my $value = $uri->$method;
-    $value = lc $value if $lc;
+    my $value = $uri->can($method) ? $uri->$method : undef;
+    $value = lc $value if $lc && defined $value;
     my $check = $convert->($expect);
 
     if($^O eq 'MSWin32' && $method eq 'path')

--- a/t/00_diag.t
+++ b/t/00_diag.t
@@ -15,6 +15,7 @@ $modules{$_} = $_ for qw(
   Mojolicious
   Test2::Compare
   Test2::Compare::Base
+  Test2::Compare::Custom
   Test2::Compare::Hash
   Test2::Compare::String
   Test2::V0

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -55,7 +55,7 @@ subtest 'non object references' => sub {
     },
     'fails when given undef',
   );
-  
+
   note $_->message for grep { $_->isa('Test2::Event::Diag') } @$e;
 
   is(
@@ -164,7 +164,7 @@ subtest 'component' => sub {
       url_component fragment  => 'fragment';
     },
   );
-  
+
   is(
     'http://foo:bar@example.com:1234/some/path?baz=1#fragment',
     url {
@@ -198,7 +198,7 @@ subtest 'component' => sub {
       },
       "$name does not match",
     );
-  
+
     note $_->message for grep { $_->isa('Test2::Event::Diag') } @$e;
   }
 
@@ -219,7 +219,7 @@ subtest 'component' => sub {
     },
     "query does not match hashref",
   );
-  
+
   note $_->message for grep { $_->isa('Test2::Event::Diag') } @$e;
 
   is(
@@ -237,7 +237,7 @@ subtest 'component' => sub {
     },
     "query does not match array",
   );
-  
+
   note $_->message for grep { $_->isa('Test2::Event::Diag') } @$e;
 };
 
@@ -267,7 +267,7 @@ subtest 'url_base' => sub {
       url_component port => 80;
     },
   );
-  
+
   url_base undef;
 
 };
@@ -410,6 +410,47 @@ subtest 'url_mail_to' => sub {
     },
     'mail to fail with non-mailto URL',
   );
+
+};
+
+subtest 'ftp URLs' => sub {
+
+  is(
+    'ftp://plicease:pass@foo.test/',
+    url {
+      url_component 'user' => 'plicease';
+      url_component 'password' => 'pass';
+    },
+    'url user + password test pass',
+  );
+
+  is(
+    intercept { is('ftp://plicease:pass@foo.test/', url { url_component 'user' => 'bad' } ) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url user test fail',
+  );
+
+  is(
+    intercept { is('ftp://plicease:pass@foo.test/', url { url_component 'password' => 'bad' } ) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url user test fail',
+  );
+
+  is(
+    intercept { is("http://foo.test/", url { url_component 'user' => 'bad'; url_component 'password' => 'bad'; }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url user + password test fail on non-FTP URL',
+  );
+
 
 };
 

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -5,6 +5,8 @@ imported_ok $_ for qw(
   url
   url_base
   url_component
+  url_scheme
+  url_host
 );
 
 subtest 'as string' => sub {
@@ -296,6 +298,30 @@ subtest 'query as hash with repeated keys' => sub {
     },
     "expected query for hashref with repeated keys"
   );
+};
+
+subtest 'url_scheme' => sub {
+
+  is(
+    "htTp://foo.bar/",
+    url {
+      url_scheme 'http';
+    },
+    "test scheme in mixed case",
+  );
+
+};
+
+subtest 'url_host' => sub {
+
+  is(
+    "http://fOo.bar/",
+    url {
+      url_host 'foo.bar';
+    },
+    "test host in mixed case",
+  );
+
 };
 
 done_testing

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -451,6 +451,53 @@ subtest 'ftp URLs' => sub {
     'url user + password test fail on non-FTP URL',
   );
 
+};
+
+subtest 'data URLs' => sub {
+
+  my $url = URI->new('data:');
+  $url->media_type('text/plain');
+  $url->data('Hello, World!');
+  $url = "$url";
+
+  note "url = $url";
+
+  is(
+    $url,
+    url {
+      url_component 'media_type' => 'text/plain';
+      url_component 'data'       => 'Hello, World!';
+    },
+    'url media type + data test pass',
+  );
+
+  is(
+    intercept { is($url, url { url_component 'media_type' => 'foo' }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url media type fail',
+  );
+
+  is(
+    intercept { is($url, url { url_component 'data' => 'foo' }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url data fail',
+  );
+
+  is(
+    intercept { is("http://foo.test", url { url_component 'media_type' => 'foo'; url_component 'data' => 'foo' }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'url media_type + data fail on non-data URL',
+  );
+
 
 };
 

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -7,6 +7,8 @@ imported_ok $_ for qw(
   url_component
   url_scheme
   url_host
+  url_secure
+  url_insecure
 );
 
 subtest 'as string' => sub {
@@ -310,6 +312,15 @@ subtest 'url_scheme' => sub {
     "test scheme in mixed case",
   );
 
+  is(
+    intercept { is("http:://foo", url { url_scheme 'ftp' }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'test schme fail',
+  );
+
 };
 
 subtest 'url_host' => sub {
@@ -320,6 +331,53 @@ subtest 'url_host' => sub {
       url_host 'foo.bar';
     },
     "test host in mixed case",
+  );
+
+  is(
+    intercept { is("http:://foo", url { url_host 'baz' }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'test schme fail',
+  );
+
+};
+
+subtest 'url_secure / url_insecure' => sub {
+
+  is(
+    "https://foo.bar",
+    url {
+      url_secure();
+    },
+    'secure pass',
+  );
+
+  is(
+    intercept { is("https://foo.bar", url { url_insecure() }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'insecure fail',
+  );
+
+  is(
+    "http://foo.bar",
+    url {
+      url_insecure();
+    },
+    'insecure pass',
+  );
+
+  is(
+    intercept { is("http://foo.bar", url { url_secure() }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'secure fail',
   );
 
 };

--- a/t/test2_tools_url.t
+++ b/t/test2_tools_url.t
@@ -9,6 +9,7 @@ imported_ok $_ for qw(
   url_host
   url_secure
   url_insecure
+  url_mail_to
 );
 
 subtest 'as string' => sub {
@@ -378,6 +379,36 @@ subtest 'url_secure / url_insecure' => sub {
       end;
     },
     'secure fail',
+  );
+
+};
+
+subtest 'url_mail_to' => sub {
+
+  is(
+    'mailto:plicease@foo.test',
+    url {
+      url_mail_to 'plicease@foo.test';
+    },
+    'matches good',
+  );
+
+  is(
+    intercept { is('mailto:plicease@foo.test', url { url_mail_to "baz" }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'mail to fail',
+  );
+
+  is(
+    intercept { is('http://foo.test', url { url_mail_to "baz" }) },
+    array {
+      event 'Fail';
+      end;
+    },
+    'mail to fail with non-mailto URL',
   );
 
 };


### PR DESCRIPTION
This add additional checks, including some from #1 

Notably we are adding a `url_host` check that checks the host name, but normalized to lower case, which is different from how `url_component 'host', $check` works.  We are leaving the latter unchanged for backward compatibility.